### PR TITLE
Update Cart.php

### DIFF
--- a/src/Cart.php
+++ b/src/Cart.php
@@ -487,7 +487,7 @@ class Cart
             $cartItem->setQuantity($qty);
         }
 
-        if($taxrate) {
+        if(isset($taxrate) && is_numeric($taxrate)) {
             $cartItem->setTaxRate($taxrate);
         } else {
             $cartItem->setTaxRate(config('cart.tax'));


### PR DESCRIPTION
Fixed a bug where 0 is passed as the taxrate to the Cart:add facade resulting in it not evaluating right since '0' is not true in a if statement. Changed therefore the comparison to isset() so it rather checks if there is passed a taxrate of some kind. Also added in the if statement a simple check to see if the taxrate is numeric, and if not default to the one in the config