### PR TITLE
fix return tag in cart methods using numberFormat

### DIFF
--- a/src/Cart.php
+++ b/src/Cart.php
@@ -256,7 +256,7 @@ class Cart
      * @param int    $decimals
      * @param string $decimalPoint
      * @param string $thousandSeperator
-     * @return float
+     * @return string
      */
     public function tax($decimals = null, $decimalPoint = null, $thousandSeperator = null)
     {
@@ -275,7 +275,7 @@ class Cart
      * @param int    $decimals
      * @param string $decimalPoint
      * @param string $thousandSeperator
-     * @return float
+     * @return string
      */
     public function subtotal($decimals = null, $decimalPoint = null, $thousandSeperator = null)
     {


### PR DESCRIPTION
Both `tax` and `subtotal` return `numberFormat()`, which returns the result of a `number_format` call: `string`.

https://github.com/hardevine/LaravelShoppingcart/blob/42902040472895e495a50a9ccaab5d99129b05ff/src/Cart.php#L253-L270

https://github.com/hardevine/LaravelShoppingcart/blob/42902040472895e495a50a9ccaab5d99129b05ff/src/Cart.php#L272-L289

https://github.com/hardevine/LaravelShoppingcart/blob/42902040472895e495a50a9ccaab5d99129b05ff/src/Cart.php#L555-L577